### PR TITLE
fixed project depending on Django 1.7 but silently requiring 1.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-Django>=1.7
+Django>=1.8
 jsonfield==1.0.3


### PR DESCRIPTION
With Django 1.7.5:

``` python
Traceback (most recent call last):
  File "dtv_test.py", line 33, in <module>
    url("^", include("infotv.urls")),
  File "/Users/japsu/Hobby/venv-desusaitti/lib/python2.7/site-packages/django/conf/urls/__init__.py", line 28, in include
    urlconf_module = import_module(urlconf_module)
  File "/usr/local/Cellar/python/2.7.9/Frameworks/Python.framework/Versions/2.7/lib/python2.7/importlib/__init__.py", line 37, in import_module
    __import__(name)
  File "/Users/japsu/Hobby/infotv/infotv/urls.py", line 4, in <module>
    from .views import InfoTvView
  File "/Users/japsu/Hobby/infotv/infotv/views.py", line 12, in <module>
    from .policy import get_policy
  File "/Users/japsu/Hobby/infotv/infotv/policy.py", line 3, in <module>
    from django.core.signals import setting_changed
ImportError: cannot import name setting_changed
```

https://docs.djangoproject.com/en/1.8/ref/signals/#setting-changed
