### PR TITLE
add babel-polyfill to survive android 4

### DIFF
--- a/infotv/frontend/package.json
+++ b/infotv/frontend/package.json
@@ -14,6 +14,7 @@
   "private": true,
   "devDependencies": {
     "babel-eslint": "^6.0.0",
+    "babel-polyfill": "^6.23.0",
     "eslint": "^2.5.1",
     "eslint-config-airbnb": "^9.0.1",
     "eslint-import-resolver-webpack": "^0.3.0",

--- a/infotv/frontend/src/main.js
+++ b/infotv/frontend/src/main.js
@@ -1,5 +1,7 @@
 /* eslint-disable new-cap, no-param-reassign */
 
+import "babel-polyfill";
+
 import React from "react";
 import ReactDOM from "react-dom";
 import TV from "./tv.jsx";


### PR DESCRIPTION
The Tampere Hall info monitors run Android 4. Its stock browser does not provide `Promise` or `Object.assign`.